### PR TITLE
Don't audit non-test calls (such as pytest-black or pytest-flake8)

### DIFF
--- a/pytest_reraise/reraise.py
+++ b/pytest_reraise/reraise.py
@@ -126,9 +126,7 @@ def reraise():
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)
 def pytest_runtest_call(item: Item):
     result = yield
-    if not hasattr(item, "funcargs"):
-        return  # only look at actual failing test calls, not setup/teardown
-    if "reraise" in item.funcargs:
+    if hasattr(item, "funcargs") and "reraise" in item.funcargs:
         reraise = item.funcargs["reraise"]
 
         # Override any non-re-raised exception in the main thread by calling `reraise()`

--- a/pytest_reraise/reraise.py
+++ b/pytest_reraise/reraise.py
@@ -126,6 +126,8 @@ def reraise():
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)
 def pytest_runtest_call(item: Item):
     result = yield
+    if not hasattr(item, "funcargs"):
+        return  # only look at actual failing test calls, not setup/teardown
     if "reraise" in item.funcargs:
         reraise = item.funcargs["reraise"]
 


### PR DESCRIPTION
If you try and run `pytest -m flake8 --flake8 ` with this plugin installed, you get the following error:


> pytest_reraise/reraise.py:129: in pytest_runtest_call
>     if "reraise" in item.funcargs:
> E   AttributeError: 'Flake8Item' object has no attribute 'funcargs'
>         item       = <Flake8Item test_construction.py>
>         result     = <pluggy.callers._Result object at 0x7fd4f0fe3340>

Checking for the attrib seems sufficient to avoid this error.